### PR TITLE
Bug - Locate and replace multi line redefinitions

### DIFF
--- a/cmd/pkg/copybook/copybook.go
+++ b/cmd/pkg/copybook/copybook.go
@@ -69,13 +69,14 @@ func (c *Copybook) RemoveRecord(r *Record) error {
 // over multiple lines in a copybook file, and replace its name with
 // the source of the REDEFINES statement, otherwise failing if
 // the target is not found.
-func (c *Copybook) RedefineRecord(want *Record) error {
+func (c *Copybook) RedefineRecord(want *Record, was string) error {
 	cc := *c
 	for i, rec := range cc.Records {
-		if rec.Name == want.Name {
+		if rec.Name == was {
 			cc.Records[i] = want
+			return nil
 		}
 	}
 
-	return fmt.Errorf("replacement target %s not found", want.Name)
+	return fmt.Errorf("replacement target %s not found", was)
 }

--- a/example/example.go
+++ b/example/example.go
@@ -13,13 +13,13 @@ type Copybookexample struct {
 	DUMMYGROUP1OBJECTC    uint     `pic:"4"`     // start:6 end:9
 	DUMMYGROUP1OBJECTD    string   `pic:"40"`    // start:10 end:49
 	DUMMYGROUP1OBJECTE    string   `pic:"8"`     // start:50 end:57
-	DUMMYGROUP1OBJECTF    string   `pic:"2"`     // start:58 end:59
+	DUMMYGROUP1OBJECTG    string   `pic:"2"`     // start:58 end:59
 	DUMMYGROUP1OBJECTH    uint     `pic:"4"`     // start:60 end:63
 	DUMMYGROUP2OBJECTA    string   `pic:"14"`    // start:64 end:77
 	DUMMYGROUP2OBJECTB    uint     `pic:"7"`     // start:78 end:84
 	DUMMYGROUP2OBJECTC    string   `pic:"4"`     // start:85 end:88
 	DUMMYGROUP2OBJECTD    string   `pic:"1"`     // start:89 end:89
-	DUMMYGROUP2OBJECTE    string   `pic:"7"`     // start:90 end:96
+	DUMMYGROUP2OBJECTF    string   `pic:"7"`     // start:90 end:96
 	DUMMYSUBGROUP2OBJECTA []string `pic:"12,12"` // start:97 end:240
 	DUMMYGROUP2OBJECTG    string   `pic:"12"`    // start:241 end:252
 	DUMMYGROUP2OBJECTH    string   `pic:"12"`    // start:253 end:264


### PR DESCRIPTION
Fixes a redefinition bug with multi-line declarations.
Replacements weren't being correctly made and errors were always being returned