### PR TITLE
Fix - Various bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,10 @@ run: build
 	chmod +x ./dist/gopic
 	./dist/gopic dir -i dummy -o dummyout
 
+.PHONY: example
+example: install
+	gopic file -o example/example.go -i example/ExampleCopybook.txt
+
 define CHECK_COVERAGE
 awk \
   -F '[ 	%]+' \

--- a/cmd/pkg/cmd/root.go
+++ b/cmd/pkg/cmd/root.go
@@ -124,7 +124,7 @@ func run(r io.Reader, output string) error {
 	name := strings.TrimSuffix(output, filepath.Ext(output))
 	n := name[strings.LastIndex(name, "/")+1:]
 
-	c := copybook.New(n, template.CopyBook)
+	c := copybook.New(n, template.Copybook())
 
 	b, err := ioutil.ReadAll(r)
 	if err != nil {

--- a/cmd/pkg/decoder/decode_test.go
+++ b/cmd/pkg/decoder/decode_test.go
@@ -20,7 +20,7 @@ func TestDecoder_Unmarshal(t *testing.T) {
 	}{
 		{
 			name: "SuccessfullyParseBasicDummyCopybook",
-			c:    copybook.New("dummy", template.CopyBook),
+			c:    copybook.New("dummy", template.Copybook()),
 			in: `000600         10  DUMMY-1                PIC X.                  00000167
 000610         10  DUMMY-2                PIC X(3).               00000168
 000620         10  DUMMY-3                PIC 9(7).               00000169
@@ -75,7 +75,7 @@ func Test_decoder_findDataRecord(t *testing.T) {
 		{
 			name: "BasicPICStringSingle",
 			line: "000600         10  DUMMY-1                PIC X.                  00000167",
-			c:    copybook.New("dummy", template.CopyBook),
+			c:    copybook.New("dummy", template.Copybook()),
 			want: &copybook.Record{
 				Num:     600,
 				Level:   10,
@@ -86,7 +86,7 @@ func Test_decoder_findDataRecord(t *testing.T) {
 		}, {
 			name: "BasicPICStringParentheses",
 			line: "000610         10  DUMMY-2                PIC X(3).               00000168",
-			c:    copybook.New("dummy", template.CopyBook),
+			c:    copybook.New("dummy", template.Copybook()),
 			want: &copybook.Record{
 				Num:     610,
 				Level:   10,
@@ -97,7 +97,7 @@ func Test_decoder_findDataRecord(t *testing.T) {
 		}, {
 			name: "BasicPICUintParentheses",
 			line: "000620         10  DUMMY-3                PIC 9(7).               00000169",
-			c:    copybook.New("dummy", template.CopyBook),
+			c:    copybook.New("dummy", template.Copybook()),
 			want: &copybook.Record{
 				Num:     620,
 				Level:   10,
@@ -108,7 +108,7 @@ func Test_decoder_findDataRecord(t *testing.T) {
 		}, {
 			name: "BasicPICStringMulti",
 			line: "000640         10  DUMMY-5                PIC XX.                 00000171",
-			c:    copybook.New("dummy", template.CopyBook),
+			c:    copybook.New("dummy", template.Copybook()),
 			want: &copybook.Record{
 				Num:     640,
 				Level:   10,
@@ -119,18 +119,18 @@ func Test_decoder_findDataRecord(t *testing.T) {
 		}, {
 			name: "MultiTypeMultiParenthesesNumber",
 			line: "000640         10  DUMMY-5                PIC S9(9)V9(9).                 00000171",
-			c:    copybook.New("dummy", template.CopyBook),
+			c:    copybook.New("dummy", template.Copybook()),
 			want: &copybook.Record{
 				Num:     640,
 				Level:   10,
 				Name:    "DUMMY-5",
-				Picture: reflect.Int,
+				Picture: reflect.Float64,
 				Length:  20,
 			},
 		}, {
 			name: "MultiTypeMultiParenthesesString",
 			line: "000640         10  DUMMY-5                PIC A(9)V9(9).                 00000171",
-			c:    copybook.New("dummy", template.CopyBook),
+			c:    copybook.New("dummy", template.Copybook()),
 			want: &copybook.Record{
 				Num:     640,
 				Level:   10,

--- a/cmd/pkg/decoder/lines.go
+++ b/cmd/pkg/decoder/lines.go
@@ -36,12 +36,12 @@ var (
 	// Defines picture clause
 	// 000600         10  DUMMY-1       PIC X.                  00000167
 	// 000620         10  DUMMY-2       PIC 9(7).               00000169
-	generousPICLine = regexp.MustCompile(`^[0-9]+ +[0-9]{2} +[a-zA-Z0-9\-]+ +PIC [AXPVS()0-9]+\. +0+[0-9]+$`)
+	generousPICLine = regexp.MustCompile(`^[0-9]+ +[0-9]{2} +[a-zA-Z0-9\-]+ +PIC [.AXPVS()0-9]+\. +0+[0-9]+$`)
 
 	// Defines picture clause that deviates from typical pattern
 	//          10  DUMMY-1       PIC X.                  00000167
 	//          10  DUMMY-2       PIC 9(7).               00000169
-	generousIncompletePICLine = regexp.MustCompile(`[0-9]{2} +[a-zA-Z0-9\-]+ +PIC [AXPVS()0-9]+\.`)
+	generousIncompletePICLine = regexp.MustCompile(`[0-9]{2} +[a-zA-Z0-9\-]+ +PIC [.AXPVS()0-9]+\.`)
 
 	// Matches same-line REDEFINES definitions
 	// 000550     05  DUMMY-1  PIC X(340).             00000162

--- a/cmd/pkg/decoder/lines_test.go
+++ b/cmd/pkg/decoder/lines_test.go
@@ -36,6 +36,10 @@ func Test_getLineType(t *testing.T) {
 			name: "BasicPICNumberNoPeriodPotentialOccursTarget",
 			line: "12345 01 NAME PIC 9(9) 054321",
 			want: occursMulti,
+		}, {
+			name: "RegularPICLiteralDot",
+			line: "12345 01 NAME PIC 9(9).9(9). 054321",
+			want: pic,
 		},
 	}
 	for _, test := range tests {

--- a/cmd/pkg/decoder/util.go
+++ b/cmd/pkg/decoder/util.go
@@ -29,7 +29,8 @@ var (
 // that contains a PIC definition
 func parsePICType(s string) reflect.Kind {
 	picType := unknown
-	if strings.ContainsAny(s, "XA") {
+	s = strings.TrimRight(s, ".")
+	if strings.ContainsAny(s, "XA.") {
 		if alpha > picType {
 			picType = alpha
 			return types[picType]
@@ -55,7 +56,7 @@ func parsePICType(s string) reflect.Kind {
 // PIC definition such as: X(2)., XX., 9(9)., etc.
 func parsePICCount(s string) (int, error) {
 	// prepare a slice of runes, representing the string
-	s = strings.Trim(s, ".")
+	s = strings.TrimRight(s, ".")
 	c := []rune(s)
 
 	size := 0

--- a/cmd/pkg/decoder/util.go
+++ b/cmd/pkg/decoder/util.go
@@ -13,7 +13,13 @@ const (
 	unknown picType = iota
 	unsigned
 	signed
+	decimal
 	alpha
+
+	alphaIndicators     = "XA"
+	decimalIndicators   = ".VP"
+	signedIntIndicators = "S"
+	intIndicators       = "9"
 )
 
 var (
@@ -21,6 +27,7 @@ var (
 		unknown:  reflect.Invalid,
 		unsigned: reflect.Uint,
 		signed:   reflect.Int,
+		decimal:  reflect.Float64,
 		alpha:    reflect.String,
 	}
 )
@@ -30,21 +37,28 @@ var (
 func parsePICType(s string) reflect.Kind {
 	picType := unknown
 	s = strings.TrimRight(s, ".")
-	if strings.ContainsAny(s, "XA.") {
+	if strings.ContainsAny(s, alphaIndicators) {
 		if alpha > picType {
 			picType = alpha
 			return types[picType]
 		}
 	}
 
-	if strings.ContainsAny(s, "S") {
+	if strings.ContainsAny(s, decimalIndicators) {
+		if decimal > picType {
+			picType = decimal
+			return types[picType]
+		}
+	}
+
+	if strings.ContainsAny(s, signedIntIndicators) {
 		if signed > picType {
 			picType = signed
 			return types[picType]
 		}
 	}
 
-	if strings.ContainsAny(s, "VP9") {
+	if strings.ContainsAny(s, intIndicators) {
 		picType = unsigned
 		return types[picType]
 	}

--- a/cmd/pkg/decoder/util_test.go
+++ b/cmd/pkg/decoder/util_test.go
@@ -90,7 +90,7 @@ func Test_parsePICType(t *testing.T) {
 		}, {
 			name: "SWithParenthesesSingleDigitDecimalPlace",
 			in:   "S9(9)V9(9).",
-			want: reflect.Int,
+			want: reflect.Float64,
 		}, {
 			name: "MultiParenthesesWithAlphanumeric",
 			in:   "S(9)VX(9).",

--- a/cmd/pkg/decoder/util_test.go
+++ b/cmd/pkg/decoder/util_test.go
@@ -41,6 +41,10 @@ func Test_parsePICCount(t *testing.T) {
 			name: "SignedNumberWithMultiParentheses",
 			in:   "S9(9)V9(9).",
 			want: 20,
+		}, {
+			name: "SignedNumberWithMultiParenthesesLiteralPeriod",
+			in:   "S9(9).9(9).",
+			want: 20,
 		},
 	}
 	for _, test := range tests {

--- a/cmd/pkg/template/template.go
+++ b/cmd/pkg/template/template.go
@@ -20,7 +20,7 @@ var (
 	}
 )
 
-var CopyBook = template.Must(
+var copyBook = template.Must(
 	template.New("struct").
 		Funcs(templateFuncs).
 		Parse(`
@@ -39,6 +39,13 @@ type Copybook{{.Name}} struct {
 	{{- end}}
 }
 `))
+
+func Copybook() *template.Template {
+	startPos = 1
+	endPos = 1
+
+	return copyBook
+}
 
 // goType translates a type into a go type
 func goType(t reflect.Kind, i int) string {

--- a/cmd/pkg/template/template.go
+++ b/cmd/pkg/template/template.go
@@ -30,7 +30,7 @@ var copyBook = template.Must(
 ////////////////////////////////
 
 // nolint
-package tempcopybook
+package copygen
 
 // Copybook{{.Name}} contains a representation of your provided Copybook
 type Copybook{{.Name}} struct {

--- a/cmd/pkg/template/template.go
+++ b/cmd/pkg/template/template.go
@@ -49,25 +49,25 @@ func Copybook() *template.Template {
 
 // goType translates a type into a go type
 func goType(t reflect.Kind, i int) string {
+	tag := ""
 	switch t {
 	case reflect.String:
-		if i > 0 {
-			return "[]string"
-		}
-		return "string"
+		tag = "string"
 	case reflect.Int:
-		if i > 0 {
-			return "[]int"
-		}
-		return "int"
+		tag = "int"
 	case reflect.Uint:
-		if i > 0 {
-			return "[]uint"
-		}
-		return "uint"
+		tag = "uint"
+	case reflect.Float64:
+		tag = "float64"
 	default:
 		panic(fmt.Sprintf("unrecognized type %v", t))
 	}
+
+	if i > 0 {
+		tag = fmt.Sprintf("[]%s", tag)
+	}
+
+	return tag
 }
 
 func picTag(l int, i int) string {

--- a/decode.go
+++ b/decode.go
@@ -62,7 +62,7 @@ func (d *Decoder) scanLine(v reflect.Value) (bool, error) {
 	l := string(d.s.Bytes())
 	t := v.Type()
 
-	set := newSetFunc(t, 0)
+	set := newSetFunc(t, 0, 0)
 	return true, set(v, l)
 }
 

--- a/example/ExampleCopybook.txt
+++ b/example/ExampleCopybook.txt
@@ -21,7 +21,7 @@
 000430             15  DUMMY-GROUP-1-OBJECT-H   PIC 9(4).               00000144
 000550     05  DUMMY-GROUP-2                    PIC X(201).             00000162
 000830     05  DUMMY-GROUP-3     REDEFINES      DUMMY-GROUP-2.          00000195
-000840         10  DUMMY-GROUP-2-OBJECT-A       PIC X(14).              00000196
+000840         10  DUMMY-GROUP-2-OBJECT-A       PIC 9(11).9(2).         00000196
 000850         10  DUMMY-GROUP-2-OBJECT-B       PIC 9(7).               00000197
 001060         10  DUMMY-GROUP-2-OBJECT-C       PIC XXXX.               00000218
 001070         10  DUMMY-GROUP-2-OBJECT-D       PIC X.                  00000219

--- a/example/example.go
+++ b/example/example.go
@@ -15,7 +15,7 @@ type Copybookexample struct {
 	DUMMYGROUP1OBJECTE    string   `pic:"8"`     // start:50 end:57
 	DUMMYGROUP1OBJECTG    string   `pic:"2"`     // start:58 end:59
 	DUMMYGROUP1OBJECTH    uint     `pic:"4"`     // start:60 end:63
-	DUMMYGROUP2OBJECTA    uint     `pic:"14"`    // start:64 end:77
+	DUMMYGROUP2OBJECTA    float64  `pic:"14"`    // start:64 end:77
 	DUMMYGROUP2OBJECTB    uint     `pic:"7"`     // start:78 end:84
 	DUMMYGROUP2OBJECTC    string   `pic:"4"`     // start:85 end:88
 	DUMMYGROUP2OBJECTD    string   `pic:"1"`     // start:89 end:89

--- a/example/example.go
+++ b/example/example.go
@@ -15,7 +15,7 @@ type Copybookexample struct {
 	DUMMYGROUP1OBJECTE    string   `pic:"8"`     // start:50 end:57
 	DUMMYGROUP1OBJECTF    string   `pic:"2"`     // start:58 end:59
 	DUMMYGROUP1OBJECTH    uint     `pic:"4"`     // start:60 end:63
-	DUMMYGROUP2OBJECTA    string   `pic:"14"`    // start:64 end:77
+	DUMMYGROUP2OBJECTA    uint     `pic:"14"`    // start:64 end:77
 	DUMMYGROUP2OBJECTB    uint     `pic:"7"`     // start:78 end:84
 	DUMMYGROUP2OBJECTC    string   `pic:"4"`     // start:85 end:88
 	DUMMYGROUP2OBJECTD    string   `pic:"1"`     // start:89 end:89

--- a/tag.go
+++ b/tag.go
@@ -59,7 +59,7 @@ func makeStructRepresentation(t reflect.Type) structRepresentation {
 		sr.fields[i].start = s
 		sr.fields[i].end = e
 		sr.fields[i].err = err
-		sr.fields[i].setFunc = newSetFunc(f.Type, occursSize)
+		sr.fields[i].setFunc = newSetFunc(f.Type, l, occursSize)
 		if sr.fields[i].end > sr.len {
 			sr.len = sr.fields[i].end
 		}


### PR DESCRIPTION
- Regenerated example
- Support explicit period handling in PIC definitions. Fixes #15 
- Fix bug where OCCURS value lost first character of input Fixes #16 
- Fix bug where start/end position comments not reset when using copybook directory mode Fixes #17 
- Fix treatment of the V & P symbols (length still incorrect #13), explicit period, when generating appropriate type (float) Fixes #18 
